### PR TITLE
Fixed PG thrown warning about incorrect type

### DIFF
--- a/lib/with_advisory_lock/postgresql.rb
+++ b/lib/with_advisory_lock/postgresql.rb
@@ -64,7 +64,7 @@ module WithAdvisoryLock
     end
 
     def execute_successful?(pg_function)
-      sql = "SELECT #{pg_function}(#{lock_keys.join(',')}) AS #{unique_column_name}"
+      sql = "SELECT #{pg_function}(#{lock_keys.join(',')})::text AS #{unique_column_name}"
       result = connection.select_value(sql)
       # MRI returns 't', jruby returns true. YAY!
       (result == 't' || result == '' || result == true)


### PR DESCRIPTION
Fixed `unknown OID 2278: failed to recognize type of 't4b142fb5b5b64b0f11e8a1143fb0c961'. It will be treated as String.` by transforming result to text.
Reason: `pg_advisory_xact_lock has no return value (the type with that OID is void). Use execute instead.`

Before:
```ruby
2.4.1 :001 > ApplicationRecord.with_advisory_lock(SecureRandom.uuid){ User.first.touch }
[WithAdvisoryLock]#with_advisory_lock lock_name: e4e0d086-48e6-4162-8703-834355edc1f3
   (6.1ms)  SELECT pg_advisory_lock(656858663,0) AS t4b142fb5b5b64b0f11e8a1143fb0c961
unknown OID 2278: failed to recognize type of 't4b142fb5b5b64b0f11e8a1143fb0c961'. It will be treated as String.
  User Load (2.8ms)  SELECT  "users".* FROM "users" WHERE "users"."deleted_at" IS NULL ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1]]
   (0.3ms)  BEGIN
  SQL (1.1ms)  UPDATE "users" SET "updated_at" = '2017-11-17 15:09:19.325185' WHERE "users"."id" = $1  [["id", "0b2122ac-3cdd-4f21-8b68-ba3c4795eafe"]]
   (6.3ms)  COMMIT
  Transaction duration (10.6ms)
   (0.5ms)  SELECT pg_advisory_unlock(656858663,0) AS t4fbf6079fdeb232520d7a6957d1628b6
 => true
```

After:
```ruby
2.4.1 :001 > ApplicationRecord.with_advisory_lock(SecureRandom.uuid){ User.first.touch }
[WithAdvisoryLock]#with_advisory_lock lock_name: 5c96dc74-c52f-423f-87b4-7f2f593ab6c7
   (0.3ms)  SELECT pg_advisory_lock(911631368,0)::text AS teeecc1c8708f942891d80f191b0f4936
  User Load (1.2ms)  SELECT  "users".* FROM "users" WHERE "users"."deleted_at" IS NULL ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1]]
   (0.3ms)  BEGIN
  SQL (1.0ms)  UPDATE "users" SET "updated_at" = '2017-11-17 15:13:33.281236' WHERE "users"."id" = $1  [["id", "0b2122ac-3cdd-4f21-8b68-ba3c4795eafe"]]
   (6.4ms)  COMMIT
  Transaction duration (10.6ms)
   (0.7ms)  SELECT pg_advisory_unlock(911631368,0)::text AS t527fc0c323ed1af854f367635bca9910
 => true
```